### PR TITLE
Fixes for Readme, Powerswitch naming and volume control

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The starting point is taken from the work of luc-ass (https://github.com/luc-ass
 This plugin is not yet on NPM. Insatllation only via GitHub at the moment...
 
 1. Install homebridge using: npm install -g homebridge <br>
-2. Install this plugin using npm install -g git+https://git@github.com/luc-ass/homebridge-marantzavr
+2. Install this plugin using npm install -g git+https://git@github.com/cellerich/homebridge-pioneeravr
 3. Update your configuration file. See sample-config below for a sample.
 
 # Configuration

--- a/index.js
+++ b/index.js
@@ -224,12 +224,11 @@ module.exports = function(homebridge) {
 
 		var informationService = new Service.AccessoryInformation();
 		informationService
-			.setCharacteristic(Characteristic.Name, this.name)
 	    		.setCharacteristic(Characteristic.Manufacturer, "Pioneer")
 	    		.setCharacteristic(Characteristic.Model, "VSX-2020")
 	    		.setCharacteristic(Characteristic.SerialNumber, "1234567890");
 
-		var switchService = new Service.Switch("Power State");
+		var switchService = new Service.Switch(this.name);
 		switchService
 			.getCharacteristic(Characteristic.On)
 				.on('get', this.getPowerState.bind(this))

--- a/index.js
+++ b/index.js
@@ -205,7 +205,11 @@ module.exports = function(homebridge) {
     },
 
   	setVolume: function(value, callback) {
-      url = this.volume_url + (value * 2 + 161) + "VL"
+        var intValue = Math.round(value * 2 + 161);
+        intValue = Math.max(intValue, 0);
+        var valueStr = ("00" + intValue).slice(-3);
+        
+        url = this.volume_url + valueStr + "VL";
 
   		this.httpRequest(url, "GET", function(error, response, body) {
         if (error) {


### PR DESCRIPTION
This pull request addresses three issues:
- It fixes the installation instructions to match your repo name instead of still referring to the marantzavr repo
- It fixes the volume control to work properly for low volumes
- It fixes the power switch accessory so that it is named using the config file name.  This is to match what seems to be convention on other home bridge plugins and to allow you to ask Siri to turn on and off your receiver using the configured name.  Prior to this change you had to ask Siri to turn on and off the "Power State" instead of the name that you gave the receiver.
