### PR TITLE
Travis testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # ignore everithing in PioneerScript Directory
 PioneerScript
 index.js.bkup
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "6.1.0"
+before_script:
+  - npm install
+script:
+  - npm test
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/cellerich/homebridge-pioneeravr.svg?branch=master)](TravisBuild)
+
 # homebridge-pioneeravr
 
 This ia a plugin for homebridge.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "v0.0.1",
   "description": "PioneerAVR plugin for homebridge: https://github.com/cellerich/homebridge-pioneeravr",
   "license": "ISC",
+  "scripts": {
+    "test": "jshint index.js"
+  },
   "keywords": [
     "homebridge-plugin"
   ],
@@ -12,5 +15,8 @@
   },
   "dependencies": {
     "request": "^2.65.0"
+  },
+  "devDependencies": {
+    "jshint": "^2.9.4"
   }
 }


### PR DESCRIPTION
Use travis to test the code with jshint to keep the code up to spec. Currently failing because of array bracket notation where the tool prefers dot notation (even after the cleanup pr, #2 )

@cellerich also needs to register for [Travis](https://travis-ci.org/) for this to actually do anything..